### PR TITLE
Repo manifest url to IBM/Manifest fixes #81

### DIFF
--- a/manifests/kfctl_ibm_tekton.yaml
+++ b/manifests/kfctl_ibm_tekton.yaml
@@ -97,5 +97,5 @@ spec:
     name: tensorboard
   repos:
   - name: manifests
-    uri: https://github.com/adrian555/manifests/archive/dojo.tar.gz
+    uri: https://github.com/IBM/manifests/archive/master.tar.gz
   version: dojo


### PR DESCRIPTION
Setting the manifest to point to IBM/Manifest for KubeflowDojo 