### PR TITLE
Changing KubeflowDojo url to point to IBM/Manifest

### DIFF
--- a/manifests/kfctl_ibm_tekton.yaml
+++ b/manifests/kfctl_ibm_tekton.yaml
@@ -97,5 +97,5 @@ spec:
     name: tensorboard
   repos:
   - name: manifests
-    uri: https://github.com/adrian555/manifests/archive/dojo.tar.gz
+    uri: https://github.com/IBM/KubeflowDojo/tree/master/manifests
   version: dojo


### PR DESCRIPTION
Changing configuration file to point to IBM/Manifest 